### PR TITLE
Generate a JSON file as a durable config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,12 +63,9 @@ target/
 #Ipython Notebook
 .ipynb_checkpoints
 .idea/
-db.sqlite3
 
+# Application generated files
 media/
-
-quotes.txt
-
-userlist.txt
-
+db.sqlite3
+streque.json
 alge/config.py

--- a/alge/settings.py
+++ b/alge/settings.py
@@ -10,33 +10,51 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
+import json
 import os
-
-#Load the config file. See config.py.sample for the structure
-import string
 import random
+import string
 
+
+# Load JSON config if available. Otherwise, if config.py exists, convert it
+# to JSON. Otherwise, just create a new one.
+filename = "streque.json"
+had_config = False
 try:
-    import alge.config as config
-except ImportError as e:
-    default_conf = """\
-# Remember to set the correct permissions for this file when in production.
-# This is done (in Linux) with the command:
-# chown *web server user*:*your user group* config.py && chmod 660 config.py
+    f = open(filename, "r")
+    config = json.load(f)
+    had_config = True
+except:
+    try:
+        import alge.config as c
+        config = {
+            "debug": c.DEBUG,
+            "secret_key": c.SECRET_KEY,
+            "email": {
+                "use_tls": c.EMAIL_USE_TLS,
+                "host": c.EMAIL_HOST,
+                "user": c.EMAIL_HOST_USER,
+                "password": c.EMAIL_HOST_PASSWORD,
+                "port": c.EMAIL_PORT,
+            },
+        }
+    except ImportError as e:
+        char = lambda: random.choice(string.ascii_letters + string.digits)
+        config = {
+            "debug": False,
+            "secret_key": ''.join(char() for _ in range(50)),
+            "email": {
+                "use_tls": True,
+                "host": None,
+                "user": None,
+                "password": None,
+                "port": 587,
+            },
+        }
 
-DEBUG = True                # False in a production environment
-SECRET_KEY = '{secret_key}'
-EMAIL_USE_TLS = True
-EMAIL_HOST = None           # smtp.gmail.com
-EMAIL_HOST_USER = None      # strecklistan@gmail.com
-EMAIL_HOST_PASSWORD = None  # Remember to set this
-EMAIL_PORT = 587
-""".format(secret_key=''.join(random.choice(string.ascii_letters + string.digits) for _ in range(50)))
-
-    with open("alge/config.py", "a") as f:
-        f.write(default_conf)
-
-    import alge.config as config
+if not had_config:
+    with open(filename, "w") as f:
+        json.dump(config, f, indent=2, sort_keys=True)
 
 
 def filter_non_strings(items):
@@ -51,13 +69,11 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config.SECRET_KEY
+SECRET_KEY = config["secret_key"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
-
-
 if 'DEBUG' in dir(config):
-    DEBUG =  config.DEBUG
+    DEBUG = config["debug"]
 else:
     DEBUG = True
 
@@ -169,23 +185,22 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static/")
 
-#Media root (uploaded files)
-
+# Media root (uploaded files)
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = '/media/'
 
-#Gmail stpm settings
+# E-mail SMTP settings
+email_config = config["email"]
+EMAIL_USE_TLS = email_config["use_tls"]
+EMAIL_HOST = email_config["host"]
+EMAIL_HOST_USER = email_config["user"]
+EMAIL_HOST_PASSWORD = email_config["password"]
+EMAIL_PORT = email_config["port"]
 
-EMAIL_USE_TLS = config.EMAIL_USE_TLS
-EMAIL_HOST = config.EMAIL_HOST
-EMAIL_HOST_USER = config.EMAIL_HOST_USER
-EMAIL_HOST_PASSWORD = config.EMAIL_HOST_PASSWORD
-EMAIL_PORT = config.EMAIL_PORT
-
-#url to login page
+# url to login page
 LOGIN_URL = '/login'
 
-#Custom user model:
+# Custom user model:
 AUTH_USER_MODEL = 'EmailUser.MyUser'
 
 REST_FRAMEWORK = {
@@ -203,7 +218,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
-    #Set page size so large numbers of data will be split up over multiple pages
+    # Set page size so large numbers of data will be split up over multiple pages
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 50,
     'MAX_PAGE_SIZE' : 200,


### PR DESCRIPTION
Don't generate Python code for config that sits alongside the rest of the code. Once the app is bundled á la #33, such files would no longer out live app updates.

Instead, opt for some other format, such as JSON. (Actual format for the config file is up for debate.)

The code converting `config.py` files to `streque.json` files is temporary, and can be removed once the active deployments have migrated.